### PR TITLE
fix: Add -nolisten local parameter to address X11 security isolation

### DIFF
--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -125,6 +125,7 @@ def get_Xdummy_command(xorg_cmd="Xorg",
         xorg_cmd,
         "-noreset", "-novtswitch",
         "-nolisten", "tcp",
+        "-nolisten", "local", 
         "+extension", "GLX",
         "+extension", "RANDR",
         "+extension", "RENDER",
@@ -145,6 +146,7 @@ def get_Xvfb_command(width=8192, height=4096, dpi=96) -> list[str]:
         "-screen", "0", f"{width}x{height}x24+32",
         # better than leaving to vfb after a resize?
         "-nolisten", "tcp",
+        "-nolisten", "local",
         "-noreset",
         "-auth", "$XAUTHORITY",
     ]


### PR DESCRIPTION
On a machine where 'xpra-start' has been executed, any other application  running on the same system can try to gain access to the X11 socket initiated by  'xpra-start'. This is an attack vector that could be explored by bad actors when  new X11 vulnerabilities come to light. 
The details of this issue are discussed in depth in the article: [X11 Security Isolation](https://tstarling.com/blog/2016/06/x11-security-isolation/).

This commit aims to address X11 security isolation concerns by introducing the  -nolisten local parameter by default in relevant sections of the xpra codebase.

[Firejail](https://firejail.wordpress.com/) optionally uses xpra to provide an  additional layer of defense, therefore, it'd be nice for xpra to enhance  default protection whenever possible.
Applying this patch shouldn't affect other parts of the system as nobody uses  unnamed X11 UNIX sockets.